### PR TITLE
Parse title and body from GitHub Event

### DIFF
--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -4,37 +4,37 @@ set -e
 
 if [ -z "$AZURE_BOARDS_ORGANIZATION" ]; 
 then
-    echo "\$AZURE_BOARDS_ORGANIZATION is not set." >&2
+    echo "AZURE_BOARDS_ORGANIZATION is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_BOARDS_PROJECT" ]; 
 then
-    echo "\$AZURE_BOARDS_PROJECT is not set." >&2
+    echo "AZURE_BOARDS_PROJECT is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_BOARDS_TOKEN" ]; 
 then
-    echo "\$AZURE_BOARDS_TOKEN is not set." >&2
+    echo "AZURE_BOARDS_TOKEN is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_BOARDS_TYPE" ]; 
 then
-    echo "\$AZURE_BOARDS_TYPE is not set." >&2
+    echo "AZURE_BOARDS_TYPE is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_BOARDS_TITLE" ]; 
 then
-    echo "\$AZURE_BOARDS_TITLE is not set." >&2
+    echo "AZURE_BOARDS_TITLE is not set." >&2
     exit 1
 fi
 
 if [ -z "$AZURE_BOARDS_DESCRIPTION" ]; 
 then
-    echo "\$AZURE_BOARDS_DESCRIPTION is not set." >&2
+    echo "AZURE_BOARDS_DESCRIPTION is not set." >&2
     exit 1
 fi
     

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -26,8 +26,8 @@ then
     exit 1
 fi
 
-AZDEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
-vsts configure --defaults instance=${AZDEVOPS_URL} project="${AZURE_BOARDS_PROJECT}"
+AZURE_DEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
+vsts configure --defaults instance=${AZURE_DEVOPS_URL} project="${AZURE_BOARDS_PROJECT}"
 
 vsts login --token ${AZURE_BOARDS_TOKEN}
 

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -26,24 +26,13 @@ then
     exit 1
 fi
 
-if [ -z "$AZURE_BOARDS_TITLE" ]; 
-then
-    echo "AZURE_BOARDS_TITLE is not set." >&2
-    exit 1
-fi
-
-if [ -z "$AZURE_BOARDS_DESCRIPTION" ]; 
-then
-    echo "AZURE_BOARDS_DESCRIPTION is not set." >&2
-    exit 1
-fi
-    
 AZDEVOPS_URL="https://dev.azure.com/${AZURE_BOARDS_ORGANIZATION}/"
 vsts configure --defaults instance=${AZDEVOPS_URL} project="${AZURE_BOARDS_PROJECT}"
-    
+
 vsts login --token ${AZURE_BOARDS_TOKEN}
 
+AZURE_BOARDS_TITLE=$(jq --raw-output .issue.title "$GITHUB_EVENT_PATH")
+AZURE_BOARDS_DESCRIPTION=$(jq --raw-output .issue.body "$GITHUB_EVENT_PATH")
+
 BOARDS_CREATE=$( vsts work item create --type "${AZURE_BOARDS_TYPE}" --title "${AZURE_BOARDS_TITLE}" --description "${AZURE_BOARDS_DESCRIPTION}" -f 80="FromGitHub" --output json )
-
-
 


### PR DESCRIPTION
GitHub Actions writes the event information to a file specified by `GITHUB_EVENT_PATH`.  Parse that file (using `jq`) for the issue title and issue body that can be provided to Azure Boards.

Additionally, update two minor points: first, don't display the `$` in the environment variable error message (that's sort of weird), and second, use `AZURE_DEVOPS_URL` as the variable, not `AZDEVOPS`.