### PR TITLE
Labels and markdown

### DIFF
--- a/boards/Dockerfile
+++ b/boards/Dockerfile
@@ -3,6 +3,13 @@ FROM microsoft/vsts-cli
 RUN apk update \
   && apk add --no-cache jq
 
+RUN wget http://www.pell.portland.or.us/~orc/Code/discount/discount-2.2.4.tar.bz2 -O /tmp/discount-2.2.4.tar.bz2 \
+  && tar xvjf /tmp/discount-2.2.4.tar.bz2 -C /tmp \
+  && cd /tmp/discount-2.2.4 \
+  && ./configure.sh \
+  && make \
+  && make install
+
 LABEL version="1.0.0"
 
 LABEL maintainer="Microsoft Corporation" 

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -55,7 +55,7 @@ GITHUB_ACTION=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 GITHUB_ISSUE_NUMBER=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
 GITHUB_ISSUE_HTML_URL=$(jq --raw-output .issue.html_url "$GITHUB_EVENT_PATH")
 AZURE_BOARDS_TITLE=$(jq --raw-output .issue.title "$GITHUB_EVENT_PATH")
-AZURE_BOARDS_DESCRIPTION=$(jq --raw-output .issue.body "$GITHUB_EVENT_PATH")
+AZURE_BOARDS_DESCRIPTION=$(jq --raw-output .issue.body "$GITHUB_EVENT_PATH" | markdown)
 
 TRIGGER="${GITHUB_EVENT}/${GITHUB_ACTION}"
 

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -104,10 +104,10 @@ case "$TRIGGER" in
 
     for ID in $(work_items_for_issue); do
         HEADER="Comment from @$(jq --raw-output .comment.user.login "$GITHUB_EVENT_PATH"): "
-        BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
+        BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH" | markdown)
 
         echo "Adding comment to work item ${ID}..."
-        RESULTS=$(vsts work item update --id "$ID" --discussion "${HEADER}${BODY}")
+        RESULTS=$(vsts work item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")
     done
     ;;
 esac

--- a/boards/entrypoint.sh
+++ b/boards/entrypoint.sh
@@ -22,6 +22,10 @@ if [ -z "$GITHUB_EVENT_PATH" ]; then
     exit 1
 fi
 
+function parse_markdown {
+    markdown -f fencedcode -f githubtags
+}
+
 function create_work_item {
     echo "Creating work item..."
     HYPERLINK="Created from <a href='${GITHUB_ISSUE_HTML_URL}'>Issue #${GITHUB_ISSUE_NUMBER}</a>"
@@ -55,7 +59,7 @@ GITHUB_ACTION=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 GITHUB_ISSUE_NUMBER=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
 GITHUB_ISSUE_HTML_URL=$(jq --raw-output .issue.html_url "$GITHUB_EVENT_PATH")
 AZURE_BOARDS_TITLE=$(jq --raw-output .issue.title "$GITHUB_EVENT_PATH")
-AZURE_BOARDS_DESCRIPTION=$(jq --raw-output .issue.body "$GITHUB_EVENT_PATH" | markdown)
+AZURE_BOARDS_DESCRIPTION=$(jq --raw-output .issue.body "$GITHUB_EVENT_PATH" | parse_markdown)
 
 TRIGGER="${GITHUB_EVENT}/${GITHUB_ACTION}"
 
@@ -104,7 +108,7 @@ case "$TRIGGER" in
 
     for ID in $(work_items_for_issue); do
         HEADER="Comment from @$(jq --raw-output .comment.user.login "$GITHUB_EVENT_PATH"): "
-        BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH" | markdown)
+        BODY=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH" | parse_markdown)
 
         echo "Adding comment to work item ${ID}..."
         RESULTS=$(vsts work item update --id "$ID" --discussion "<p>${HEADER}</p>${BODY}")


### PR DESCRIPTION
This introduces two additional enhancements;

1. Markdown parsing for the issue: the issue's description and additional comments will be parsed as markdown and converted to HTML for the Azure Board contents.
2. Support GitHub issue labels.  If the `ISSUE_LABEL` variable is set then only issues with the given label will be created as Azure Board work items.